### PR TITLE
修正 smooth Scrolling 在 desktop 時的問題

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,7 +31,7 @@ function smoothScrolling(e) {
     var menuLink = $(this.hash),
         scrollSpeed = 1000;
 
-    $('html, body').animate(
+    $('html, body, main').animate(
         {'scrollTop': menuLink.offset().top}, scrollSpeed);
 
     console.log(menuLink);


### PR DESCRIPTION
在 mobile 畫面時， <main>(主容器) 和 html, body 一樣高
但是在 desktop 時 html 和 body 則沒有和  main 一樣高
所以在 desktop 時沒有捲動效果